### PR TITLE
update SQL script for MySQL 8.x

### DIFF
--- a/src/sql/create-phpgiftregdb.sql
+++ b/src/sql/create-phpgiftregdb.sql
@@ -1,9 +1,3 @@
--- MySQL dump 9.11
---
--- Host: localhost    Database: conversion
--- ------------------------------------------------------
--- Server version	4.0.22-log
-
 --
 -- Table structure for table `allocs`
 --
@@ -14,7 +8,7 @@ CREATE TABLE `allocs` (
   `bought` tinyint(1) NOT NULL default '0',
   `quantity` int(11) NOT NULL default '0',
   PRIMARY KEY  (`itemid`,`userid`,`bought`)
-) TYPE=MyISAM;
+);
 
 --
 -- Table structure for table `categories`
@@ -24,7 +18,7 @@ CREATE TABLE `categories` (
   `categoryid` int(11) NOT NULL auto_increment,
   `category` varchar(50) default NULL,
   PRIMARY KEY  (`categoryid`)
-) TYPE=MyISAM;
+);
 
 --
 -- Dumping data for table `categories`
@@ -55,10 +49,10 @@ CREATE TABLE `events` (
   `eventid` int(11) NOT NULL auto_increment,
   `userid` int(11) default NULL,
   `description` varchar(100) NOT NULL default '',
-  `eventdate` date NOT NULL default '0000-00-00',
+  `eventdate` date NOT NULL default '2000-01-01',
   `recurring` tinyint(1) NOT NULL default '0',
   PRIMARY KEY  (`eventid`)
-) TYPE=MyISAM;
+);
 
 --
 -- Dumping data for table `events`
@@ -83,7 +77,7 @@ CREATE TABLE `items` (
   `quantity` int(11) NOT NULL default '0',
   `image_filename` varchar(255) default NULL,
   PRIMARY KEY  (`itemid`)
-) TYPE=MyISAM;
+);
 
 --
 -- Table structure for table `messages`
@@ -95,9 +89,9 @@ CREATE TABLE `messages` (
   `recipient` int(11) NOT NULL default '0',
   `message` varchar(255) NOT NULL default '',
   `isread` tinyint(1) NOT NULL default '0',
-  `created` date NOT NULL default '0000-00-00',
+  `created` date NOT NULL default '2000-01-01',
   PRIMARY KEY  (`messageid`)
-) TYPE=MyISAM;
+);
 
 --
 -- Table structure for table `ranks`
@@ -109,7 +103,7 @@ CREATE TABLE `ranks` (
   `rendered` varchar(255) NOT NULL default '',
   `rankorder` int(11) NOT NULL default '0',
   PRIMARY KEY  (`ranking`)
-) TYPE=MyISAM;
+);
 
 --
 -- Dumping data for table `ranks`
@@ -130,17 +124,17 @@ CREATE TABLE `shoppers` (
   `mayshopfor` int(11) NOT NULL default '0',
   `pending` tinyint(1) NOT NULL default '0',
   PRIMARY KEY  (`shopper`,`mayshopfor`)
-) TYPE=MyISAM;
+);
 
 --
 -- Table structure for table `families`
 --
 
-CREATE TABLE families (
+CREATE TABLE `families` (
   familyid int(11) NOT NULL auto_increment,
   familyname varchar(255) NOT NULL default '',
   PRIMARY KEY  (familyid)
-) TYPE=MyISAM;
+);
 
 --
 -- Table structure for table `users`
@@ -159,21 +153,21 @@ CREATE TABLE `users` (
   `list_stamp` datetime default NULL,
   `initialfamilyid` int NULL,
   PRIMARY KEY  (`userid`)
-) TYPE=MyISAM;
+);
 
 --
 -- Table structure for table `memberships`
 --
 
-CREATE TABLE memberships (
+CREATE TABLE `memberships` (
   userid int(11) NOT NULL default '0',
   familyid int(11) NOT NULL default '0',
   PRIMARY KEY  (userid,familyid)
-) TYPE=MyISAM;
+);
 
 CREATE TABLE `subscriptions` (
 	`publisher` int(11) NOT NULL,
 	`subscriber` int(11) NOT NULL,
 	`last_notified` datetime DEFAULT NULL,
 	PRIMARY KEY (`publisher`,`subscriber`)
-) TYPE=MyISAM;
+);


### PR DESCRIPTION
This updates the `create-phpgiftregdb.sql` file to work with MySQL 8.0.

* remove `TYPE=MyISAM` from `CREATE TABLE` statements
* provide valid `DATE` defaults 