### PR TITLE
fix bound param error

### DIFF
--- a/src/shop.php
+++ b/src/shop.php
@@ -73,7 +73,7 @@ if (!empty($_GET["action"])) {
 			$stmt->bindParam(4, $source, PDO::PARAM_STR);
 			$stmt->bindParam(5, $url, PDO::PARAM_STR);
 			$stmt->bindParam(6, $comment, PDO::PARAM_STR);
-			$stmt->bindParam(7,	$cat, PDO::PARAM_INT);
+			$stmt->bindParam(7, $cat, PDO::PARAM_INT);
 			$stmt->execute();
 		
 			stampUser($userid, $smarty->dbh(), $smarty->opt());
@@ -143,7 +143,7 @@ $stmt = $smarty->dbh()->prepare("SELECT i.itemid, description, price, source, c.
 	"LEFT OUTER JOIN {$opt["table_prefix"]}allocs a ON a.itemid = i.itemid AND i.quantity = 1 " .	// only join allocs for single-quantity items.
 	"LEFT OUTER JOIN {$opt["table_prefix"]}users ub ON ub.userid = a.userid AND a.bought = 1 " .
 	"LEFT OUTER JOIN {$opt["table_prefix"]}users ur ON ur.userid = a.userid AND a.bought = 0 " .
-	"WHERE i.userid = $shopfor " .
+	"WHERE i.userid = ? " .
 	"ORDER BY " . $sortby);
 $stmt->bindParam(1, $shopfor, PDO::PARAM_INT);
 $stmt->execute();


### PR DESCRIPTION
```
Fatal error: Uncaught PDOException: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in /home1/salattic/public_html/phpgiftreg/src/shop.php:149 Stack trace: #0 /home1/salattic/public_html/phpgiftreg/src/shop.php(149): PDOStatement->execute() #1 {main} thrown in /home1/salattic/public_html/phpgiftreg/src/shop.php on line 149
```

Everywhere else I am using `?` for bound parameters, and should do that here, too.