### PR TITLE
fix undefined variable warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/templates_c
+src/item_images
+

--- a/src/item.php
+++ b/src/item.php
@@ -181,13 +181,8 @@ if (!empty($_REQUEST["action"])) {
 	}
 	else if ($action == "insert") {
 		if (!$haserror) {
-            if (isset($image_base_filename) && $image_base_filename != "") {
-			    $stmt = $smarty->dbh()->prepare("INSERT INTO {$opt["table_prefix"]}items(userid,description,price,source,category,url,ranking,comment,quantity,image_filename) " .
-				    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-            } else {
-                $stmt = $smarty->dbh()->prepare("INSERT INTO {$opt["table_prefix"]}items(userid,description,price,source,category,url,ranking,comment,quantity) " .
-                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)");
-            }
+			$stmt = $smarty->dbh()->prepare("INSERT INTO {$opt["table_prefix"]}items(userid,description,price,source,category,url,ranking,comment,quantity,image_filename) " .
+			    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 			$stmt->bindParam(1, $userid, PDO::PARAM_INT);
 			$stmt->bindParam(2, $description, PDO::PARAM_STR);
 			$stmt->bindParam(3, $price);
@@ -197,9 +192,10 @@ if (!empty($_REQUEST["action"])) {
 			$stmt->bindParam(7, $ranking, PDO::PARAM_INT);
 			$stmt->bindParam(8, $comment, PDO::PARAM_STR);
 			$stmt->bindParam(9, $quantity, PDO::PARAM_INT);
-			if (isset($image_base_filename) && $image_base_filename != "") {
-				$stmt->bindParam(10, $image_base_filename, PDO::PARAM_STR);
-			}
+            if (!isset($image_base_filename) || $image_base_filename == "") {
+                $image_base_filename = NULL;
+            }
+			$stmt->bindParam(10, $image_base_filename, PDO::PARAM_STR);
 			$stmt->execute();
 			
 			stampUser($userid, $smarty->dbh(), $smarty->opt());

--- a/src/item.php
+++ b/src/item.php
@@ -181,8 +181,13 @@ if (!empty($_REQUEST["action"])) {
 	}
 	else if ($action == "insert") {
 		if (!$haserror) {
-			$stmt = $smarty->dbh()->prepare("INSERT INTO {$opt["table_prefix"]}items(userid,description,price,source,category,url,ranking,comment,quantity" . ($image_base_filename != "" ? ",image_filename" : "") . ") " .
-				"VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?" . ($image_base_filename != "" ? ", ?)" : ")"));
+            if (isset($image_base_filename) && $image_base_filename != "") {
+			    $stmt = $smarty->dbh()->prepare("INSERT INTO {$opt["table_prefix"]}items(userid,description,price,source,category,url,ranking,comment,quantity,image_filename) " .
+				    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            } else {
+                $stmt = $smarty->dbh()->prepare("INSERT INTO {$opt["table_prefix"]}items(userid,description,price,source,category,url,ranking,comment,quantity) " .
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            }
 			$stmt->bindParam(1, $userid, PDO::PARAM_INT);
 			$stmt->bindParam(2, $description, PDO::PARAM_STR);
 			$stmt->bindParam(3, $price);
@@ -192,7 +197,7 @@ if (!empty($_REQUEST["action"])) {
 			$stmt->bindParam(7, $ranking, PDO::PARAM_INT);
 			$stmt->bindParam(8, $comment, PDO::PARAM_STR);
 			$stmt->bindParam(9, $quantity, PDO::PARAM_INT);
-			if ($image_base_filename != "") {
+			if (isset($image_base_filename) && $image_base_filename != "") {
 				$stmt->bindParam(10, $image_base_filename, PDO::PARAM_STR);
 			}
 			$stmt->execute();


### PR DESCRIPTION
When creating an item without an image, there's a warning in the logs (which could be an error I guess?) like this:

```
[Mon May 06 21:22:58.169852 2024] [php:warn] [pid 19188] [client 192.168.0.128:58803] PHP Warning:  Undefined variable $image_base_filename in /home/ryan/projects/phpgiftreg/src/item.php on line 184, referer: http://tungsten/phpgiftreg/item.php?action=add
```

We will avoid even referring to this variable if it isn't set.