### PR TITLE
Password should be PDO::PARAM_STR, not PDO::PARAM_INT

### DIFF
--- a/src/admin.php
+++ b/src/admin.php
@@ -41,7 +41,7 @@ if ($action == "approve") {
 		$stmt->execute();
 	}
 	$stmt = $smarty->dbh()->prepare("UPDATE {$opt["table_prefix"]}users SET approved = 1, password = {$opt["password_hasher"]}(?) WHERE userid = ?");
-	$stmt->bindParam(1, $pwd, PDO::PARAM_INT);
+	$stmt->bindParam(1, $pwd, PDO::PARAM_STR);
 	$stmt->bindValue(2, (int) $_GET["userid"], PDO::PARAM_INT);
 	$stmt->execute();
 	

--- a/src/admin.php
+++ b/src/admin.php
@@ -54,7 +54,7 @@ if ($action == "approve") {
 			$row["email"],
 			"Gift Registry application approved",
 			"Your Gift Registry application was approved by " . $_SESSION["fullname"] . ".\r\n" . 
-				"Your username is " . $row["username"] . " and your password is $pwd.",
+				"Your username is " . $row["username"] . " and your password is '$pwd'.",
 			"From: {$opt["email_from"]}\r\nReply-To: {$opt["email_reply_to"]}\r\nX-Mailer: {$opt["email_xmailer"]}\r\n"
 		) or die("Mail not accepted for " . $row["email"]);	
 	}

--- a/src/signup.php
+++ b/src/signup.php
@@ -80,7 +80,7 @@ if (isset($_POST["action"]) && $_POST["action"] == "signup") {
 					$email,
 					"Gift Registry account created",
 					"Your Gift Registry account was created.\r\n" . 
-						"Your username is $username and your password is $pwd.",
+						"Your username is $username and your password is '$pwd'.",
 					"From: {$opt["email_from"]}\r\nReply-To: {$opt["email_reply_to"]}\r\nX-Mailer: {$opt["email_xmailer"]}\r\n"
 				) or die("Mail not accepted for $email");	
 			}

--- a/src/users.php
+++ b/src/users.php
@@ -136,7 +136,7 @@ else if ($action == "insert") {
 			$email,
 			"Gift Registry account created",
 			"Your Gift Registry account was created.\r\n" . 
-				"Your username is $username and your password is $pwd.",
+				"Your username is $username and your password is '$pwd'.",
 			"From: {$opt["email_from"]}\r\nReply-To: {$opt["email_reply_to"]}\r\nX-Mailer: {$opt["email_xmailer"]}\r\n"
 		) or die("Mail not accepted for $email");	
 		header("Location: " . getFullPath("users.php?message=User+added+and+e-mail+sent."));
@@ -178,7 +178,7 @@ else if ($action == "reset") {
 	mail(
 		$resetemail,
 		"Gift Registry password reset",
-		"Your Gift Registry password was reset to $pwd.",
+		"Your Gift Registry password was reset to '$pwd'.",
 		"From: {$opt["email_from"]}\r\nReply-To: {$opt["email_reply_to"]}\r\nX-Mailer: {$opt["email_xmailer"]}\r\n"
 	) or die("Mail not accepted for $email");
 	header("Location: " . getFullPath("users.php?message=Password+reset."));


### PR DESCRIPTION
When approving as user and their password is generated, it is saved as an INT instead of an STR, so the user cannot log in.