### PR TITLE
Password should be PDO::PARAM_STR, not PDO::PARAM_INT

### DIFF
--- a/src/admin.php
+++ b/src/admin.php
@@ -41,7 +41,7 @@ if ($action == "approve") {
 		$stmt->execute();
 	}
 	$stmt = $smarty->dbh()->prepare("UPDATE {$opt["table_prefix"]}users SET approved = 1, password = {$opt["password_hasher"]}(?) WHERE userid = ?");
-	$stmt->bindParam(1, $pwd, PDO::PARAM_INT);
+	$stmt->bindParam(1, $pwd, PDO::PARAM_STR);
 	$stmt->bindValue(2, (int) $_GET["userid"], PDO::PARAM_INT);
 	$stmt->execute();
 	


### PR DESCRIPTION
When approving as user and their password is generated, it is saved as an INT instead of an STR, so the user cannot log in.